### PR TITLE
6 add datecontext to quotes

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -3,6 +3,8 @@
     "cache_quote_file": "quotes.csv",
     "cache_birthday_file": "birthdays.csv",
     "display_birthdays": true,
+    "display_date": false,
+    "display_context": false,
     "enable_birthday_quotes": true,
     "database_query_period_m": 60.0,
     "query_database_on_start": false,

--- a/quote_picker.py
+++ b/quote_picker.py
@@ -4,6 +4,12 @@ import pandas as pd
 
 from typing import Optional
 
+def coerce_dates(x):
+        try:
+            return date.fromisoformat(x)
+        except ValueError:
+            return None
+
 def date_is_today(x):
         today = date.today()
         try:
@@ -31,11 +37,6 @@ def filter_quotes_by_name(quotes, names):
 
 
 def filter_quotes_by_date(quotes, target_date):
-    def coerce_dates(x):
-        try:
-            return date.fromisoformat(x)
-        except ValueError:
-            return None
     
     date_quotes = quotes.loc[~quotes['Date'].apply(coerce_dates).isna()].copy()
     

--- a/quote_server.py
+++ b/quote_server.py
@@ -8,7 +8,7 @@ from functools import partial
 import quote_updater as quote_db
 from server import HTTPHandler 
 from utils import merge_dict_into_dict, dict_keys_to_lowercase, get_server_ip, check_internet_access, RepeatTimer
-from quote_picker import pick_quote, get_current_birthdays
+from quote_picker import pick_quote, get_current_birthdays, coerce_dates
 
 from typing import Optional
 
@@ -85,6 +85,8 @@ class QuoteServerBackend:
             if self.config['display_birthdays'] and (get_current_birthdays(self.birthdays)['Name']==chosen_quote['Who']).any():
                 chosen_quote['Who'] = chosen_quote['Who'] + ' 🎂'
 
+            if self.config['display_date'] and (d:=coerce_dates(chosen_quote['Date'])) is not None:
+                chosen_quote['Date'] = f"({d:%B} {d.day}, {d:%Y})"
         else:
             # Seems the quotes have changed indices, time to get a new one
             self.change_current_quote()

--- a/root/css/index.css
+++ b/root/css/index.css
@@ -17,6 +17,26 @@ body {
     color: rgb(184, 184, 184);
     font-size: 40px;
     text-align: right;
+    margin: 0px 0px 0px auto;
+}
+
+#quote_date {
+    white-space: pre;
+    font-family: 'Times New Roman', Times, serif;
+    color: rgb(184, 184, 184);
+    font-size: 40px;
+    text-align: right;
+    margin: 0px 0px 0px auto;
+}
+
+
+#quote_context {
+    white-space: pre;
+    font-family: 'Times New Roman', Times, serif;
+    color: rgb(184, 184, 184);
+    font-size: 40px;
+    text-align: right;
+    margin: 0px 0px 0px auto;
 }
 
 #connection_loss_msg {

--- a/root/index.html
+++ b/root/index.html
@@ -34,8 +34,8 @@
     </div>
     <div style="float:right">
         <span id="quote_author"></span>
-        <span id="quote_date"></span>
         <span id="quote_context"></span>
+        <span id="quote_date"></span>
     </div>
     
     <div class="headerfooter" id="debug_footer">
@@ -123,18 +123,15 @@
                 else
                     quote_author.innerHTML = "unknown"
 
-                if ("date" in current_quote_info && current_quote_info["date"]!="")
-                    quote_date.innerHTML = " " + current_quote_info["date"]
-                else
-                    quote_date.innerHTML = ""
-                
                 if ("context" in current_quote_info && current_quote_info["context"]!="")
-                    if (quote_date.innerHTML=="" || quote_date.style.display=="none")
-                        quote_context.innerHTML = " " + current_quote_info["context"]
-                    else
-                        quote_context.innerHTML = ", " + current_quote_info["context"]
+                    quote_context.innerHTML = " " + current_quote_info["context"]
                 else
                     quote_context.innerHTML = ""
+
+                if ("date" in current_quote_info && current_quote_info["date"]!="")
+                    quote_date.innerHTML = " " + current_quote_info["date"]
+                 else
+                    quote_date.innerHTML = ""
             }
         }
 

--- a/root/index.html
+++ b/root/index.html
@@ -32,7 +32,12 @@
     <div class="center">
           <q id="quote_body"></q>
     </div>
-    <div id="quote_author"></div>
+    <div style="float:right">
+        <span id="quote_author"></span>
+        <span id="quote_date"></span>
+        <span id="quote_context"></span>
+    </div>
+    
     <div class="headerfooter" id="debug_footer">
         <span id="last_database_update" style="float:left"></span>
         <span id="device_ip" style="float:right"></span>
@@ -69,11 +74,21 @@
 
             // handle received info
             if ("config" in response) {
-                if ('debug' in response['config'] && response['config']['debug']){
+                if ('debug' in response['config'] && response['config']['debug'])
                     show_debugging_stuff()
-                } else {
+                else
                     hide_debugging_stuff()
-                }
+
+                if ('display_date' in response['config'] && response['config']['display_date'])
+                    quote_date.style.display = "inline"
+                else 
+                    quote_date.style.display = "none"
+
+                if ('display_context' in response['config'] && response['config']['display_context'])
+                    quote_context.style.display = "inline"
+                else 
+                    quote_context.style.display = "none"
+
                 // console.log(response["config"])
                 if ('sfw' in response['config'] && response['config']['sfw'] ) {
                     quote_body.innerHTML = ""
@@ -107,6 +122,19 @@
                     quote_author.innerHTML = current_quote_info["who"]
                 else
                     quote_author.innerHTML = "unknown"
+
+                if ("date" in current_quote_info && current_quote_info["date"]!="")
+                    quote_date.innerHTML = " " + current_quote_info["date"]
+                else
+                    quote_date.innerHTML = ""
+                
+                if ("context" in current_quote_info && current_quote_info["context"]!="")
+                    if (quote_date.innerHTML=="" || quote_date.style.display=="none")
+                        quote_context.innerHTML = " " + current_quote_info["context"]
+                    else
+                        quote_context.innerHTML = ", " + current_quote_info["context"]
+                else
+                    quote_context.innerHTML = ""
             }
         }
 


### PR DESCRIPTION
Added flags for displaying date and context next to name. Formatting follows the name formatting.

Display format is:

{Name} {context} ({date:Month Day, Year})

With extra spaces removed